### PR TITLE
Add the IDR nd2 image as a possibility to the Reading..IDR notebook

### DIFF
--- a/ReadingData_fromIDR.ipynb
+++ b/ReadingData_fromIDR.ipynb
@@ -96,7 +96,11 @@
    "metadata": {},
    "source": [
     "You can work in BioIO library in the provided VM or locally as described in [ImageFormat notebook](ImageFormat.ipynb). The workflow described in [ImageFormat notebook](ImageFormat.ipynb) is using an image downloaded from public images on downloads.openmicroscopy.org. \n",
-    "You can adjust this workflow to work instead with another nd2 image, this time fetched from IDR. This is the [image in IDR](https://idr.openmicroscopy.org/webclient/?show=image-11511261), from the publication [Inherent regulatory asymmetry emanating from network architecture in a prevalent autoregulatory motif](https://doi.org/10.7554/eLife.56517) by Ali et. al. 2020."
+    "You can adjust this workflow to work instead with another nd2 image, this time fetched from IDR. This is the [image in IDR](https://idr.openmicroscopy.org/webclient/?show=image-11511261), from the publication [Inherent regulatory asymmetry emanating from network architecture in a prevalent autoregulatory motif](https://doi.org/10.7554/eLife.56517) by Ali et. al. 2020. The command you need to download the image from IDR is\n",
+    "\n",
+    "```\n",
+    "wget https://ftp.ebi.ac.uk/pub/databases/IDR/idr0095-ali-asymmetry/20200831-ftp/AO1TO2-Trial2/no.nd2\n",
+    "```\n"
    ]
   },
   {

--- a/ReadingData_fromIDR.ipynb
+++ b/ReadingData_fromIDR.ipynb
@@ -92,6 +92,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f2339708",
+   "metadata": {},
+   "source": [
+    "You can work in BioIO library in the provided VM or locally as described in [ImageFormat notebook](ImageFormat.ipynb). The workflow described in [ImageFormat notebook](ImageFormat.ipynb) is using an image downloaded from public images on downloads.openmicroscopy.org. \n",
+    "You can adjust this workflow to work instead with another nd2 image, this time fetched from IDR. This is the [image in IDR](https://idr.openmicroscopy.org/webclient/?show=image-11511261), from the publication [Inherent regulatory asymmetry emanating from network architecture in a prevalent autoregulatory motif](https://doi.org/10.7554/eLife.56517) by Ali et. al. 2020."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3c95636b-b3b4-4013-b67f-31016597d5f1",
    "metadata": {},
    "source": [


### PR DESCRIPTION
I have added the new nd2 image from IDR as a text cell expanding the Reading...IDR notebook.
It refers to the workflow in the ImageFormat notebook, suggesting an option to work with an IDR image this time.

See if you want to merge it or not.