### PR TITLE
p311 -> p312 for ice wheels in Colab

### DIFF
--- a/ReadingData_fromIDR.ipynb
+++ b/ReadingData_fromIDR.ipynb
@@ -221,7 +221,7 @@
     "### Install the libraries to connect to idr\n",
     "\n",
     "# Ice Python binding\n",
-    "%pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl\n",
+    "%pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl\n",
     "\n",
     "# Package required to interact with IDR or OMERO you usually only need to install omero-py\n",
     "%pip install omero-py"


### PR DESCRIPTION
As discovered in today's testing the p311 based wheel is not working in Google Colab anymore.

Instead, the replacement of p311 with p312 was found to be working.

Opening this PR accordingly.

cc @jburel 